### PR TITLE
TAP-4936: mParticle kit not sending metadata to taplytics

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,21 @@
+name: Unit Tests
+
+on:
+  push:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Clean and Run Unit Tests
+        uses: eskatos/gradle-command-action@v1
+        with:
+          gradle-version: 6.6.1
+          arguments: clean assemble test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/src/main/java/com/mparticle/kits/TaplyticsKit.java
+++ b/src/main/java/com/mparticle/kits/TaplyticsKit.java
@@ -132,7 +132,9 @@ public class TaplyticsKit extends KitIntegration
     }
 
     @Override
-    public boolean supportsAttributeLists() { return false; }
+    public boolean supportsAttributeLists() {
+        return false;
+    }
 
     @Override
     public void setAllUserAttributes(Map<String, String> attributes, Map<String, List<String>> attributeLists) {
@@ -169,10 +171,13 @@ public class TaplyticsKit extends KitIntegration
      * Unsupported methods
      */
     @Override
-    public List<ReportingMessage> logout() { return null; }
+    public List<ReportingMessage> logout() {
+        return null;
+    }
 
     @Override
-    public void setUserAttributeList(String attribute, List<String> attributeValueList) { }
+    public void setUserAttributeList(String attribute, List<String> attributeValueList) {
+    }
 
     /**
      * CommerceListener Interface
@@ -208,8 +213,15 @@ public class TaplyticsKit extends KitIntegration
 
     @Override
     public List<ReportingMessage> logEvent(MPEvent event) {
-        String eventName = event.getEventName();
-        Taplytics.logEvent(eventName);
+        final String eventName = event.getEventName();
+        final Map<String, String> metaDataMap = event.getCustomAttributes();
+
+        JSONObject metaData = null;
+        if (metaDataMap != null) {
+            metaData = new JSONObject(metaDataMap);
+        }
+
+        Taplytics.logEvent(eventName, null, metaData);
         return Collections.singletonList(ReportingMessage.fromEvent(this, event));
     }
 
@@ -224,17 +236,25 @@ public class TaplyticsKit extends KitIntegration
      */
 
     @Override
-    public List<ReportingMessage> logException(Exception exception, Map<String, String> exceptionAttributes, String message) { return null; }
+    public List<ReportingMessage> logException(Exception exception, Map<String, String> exceptionAttributes, String message) {
+        return null;
+    }
 
     @Override
-    public List<ReportingMessage> logError(String message, Map<String, String> errorAttributes) { return null; }
+    public List<ReportingMessage> logError(String message, Map<String, String> errorAttributes) {
+        return null;
+    }
 
     @Override
-    public List<ReportingMessage> leaveBreadcrumb(String breadcrumb) { return null; }
+    public List<ReportingMessage> leaveBreadcrumb(String breadcrumb) {
+        return null;
+    }
 
     //put all these together
     @Override
-    public List<ReportingMessage> logLtvIncrease(BigDecimal valueIncreased, BigDecimal valueTotal, String eventName, Map<String, String> contextInfo) { return null; }
+    public List<ReportingMessage> logLtvIncrease(BigDecimal valueIncreased, BigDecimal valueTotal, String eventName, Map<String, String> contextInfo) {
+        return null;
+    }
 
     @Override
     public List<ReportingMessage> setOptOut(final boolean optedOut) {


### PR DESCRIPTION
Fix is in `logEvent`. It wasnt sending the meta data before. I updated it to reflect the logic in the ios integration.

The other additions you see are because I did a pull from upstream